### PR TITLE
Add check for duplication in Autocomplete

### DIFF
--- a/src/Commands/DocumentationCommand.cs
+++ b/src/Commands/DocumentationCommand.cs
@@ -95,7 +95,13 @@ namespace OoLunar.DocBot.Commands
                     continue;
                 }
 
-                choices.Add(member.DisplayName.TrimLength(100), member.GetHashCode().ToString(CultureInfo.InvariantCulture));
+                string identifier = member.DisplayName.TrimLength(100);
+                if (choices.ContainsKey(identifier))
+                {
+                    continue;
+                }
+
+                choices.Add(identifier, member.GetHashCode().ToString(CultureInfo.InvariantCulture));
                 if (choices.Count == 10)
                 {
                     break;

--- a/src/Commands/DocumentationCommand.cs
+++ b/src/Commands/DocumentationCommand.cs
@@ -94,14 +94,12 @@ namespace OoLunar.DocBot.Commands
                 {
                     continue;
                 }
-
-                string identifier = member.DisplayName.TrimLength(100);
-                if (choices.ContainsKey(identifier))
+                
+                if (!choices.TryAdd(member.DisplayName.TrimLength(100), member.GetHashCode().ToString(CultureInfo.InvariantCulture)))
                 {
                     continue;
                 }
-
-                choices.Add(identifier, member.GetHashCode().ToString(CultureInfo.InvariantCulture));
+                
                 if (choices.Count == 10)
                 {
                     break;


### PR DESCRIPTION
# Summary
The autocomplete for the documentation command can throw an error if the id is already in the dict.
This pr adds a check if its already used. We could add some kind of system to make them different if the id was trimmed, but idk how to decode it in the command invocation