### PR TITLE
Move document searcher logic to DocumentationProvider

### DIFF
--- a/src/Commands/DocumentationCommand.cs
+++ b/src/Commands/DocumentationCommand.cs
@@ -27,61 +27,63 @@ namespace OoLunar.DocBot.Commands
             _logger = logger ?? NullLoggerFactory.Instance.CreateLogger<DocumentationCommand>();
         }
 
-        [Command("documentation"), TextAlias("doc", "docs"), Description("Retrieves documentation for a given type or member.")]
-        public async Task GetDocumentationAsync(CommandContext context, [Description("Which type or member to grab documentation upon."), SlashAutoCompleteProvider<DocumentationCommand>, RemainingText] string? query = null)
+        [Command("documentation"),
+            TextAlias("doc", "docs"),
+            Description("Retrieves documentation for a given type or member.")]
+        public async Task GetDocumentationAsync(
+            CommandContext context,
+
+            [Description("Which type or member to grab documentation upon."),
+                SlashAutoCompleteProvider<DocumentationCommand>,
+                RemainingText]
+            string? query = null)
         {
-            DocumentationMember? documentation = null;
+            List<DocumentationMember> foundDocs = [];
             if (string.IsNullOrWhiteSpace(query))
             {
                 // Select a random member
-                documentation = _documentationProvider.Members.Values.ElementAt(Random.Shared.Next(_documentationProvider.Members.Count));
+                foundDocs.Add(_documentationProvider.Members.Values.ElementAt(Random.Shared.Next(_documentationProvider.Members.Count)));
             }
-            else if (!int.TryParse(query, out int id) || !_documentationProvider.Members.TryGetValue(id, out documentation))
+            else
             {
-                foreach (DocumentationMember member in _documentationProvider.Members.Values)
-                {
-                    if (member.FullName.Equals(query, StringComparison.OrdinalIgnoreCase))
+                foundDocs.AddRange(_documentationProvider.FindMatchingDocs(query));
+            }
+
+            switch (foundDocs.Count)
+            {
+                case 0:
                     {
-                        documentation = member;
-                        break;
+                        _logger.LogDebug("No documentation found for: {Query}.", query);
+                        await context.RespondAsync("No documentation found.");
+                        return;
                     }
-                    else if (member.DisplayName.Equals(query, StringComparison.OrdinalIgnoreCase))
+
+                case 1:
                     {
-                        documentation = member;
-                        break;
+                        await ReplyWithDocumentationAsync(context, foundDocs[0]);
                     }
-                    else if (member.DisplayName.Contains(query, StringComparison.OrdinalIgnoreCase))
+                    break;
+
+                case > 25:
                     {
-                        documentation = member;
+                        DiscordEmbedBuilder embedBuilder = new DiscordEmbedBuilder()
+                            .WithTitle("Refine your search!")
+                            .WithDescription($"More than 25 items matched your query ({foundDocs.Count})! Please refine your search and try again!")
+                            .WithColor(DiscordColor.Red);
+
+                        await context.RespondAsync(embedBuilder);
                     }
-                }
-            }
+                    break;
 
-            if (documentation is null)
-            {
-                _logger.LogDebug("No documentation found for: {Query}.", query);
-                await context.RespondAsync("No documentation found.");
-                return;
-            }
+                case > 1:
+                    {
+                        DiscordEmbedBuilder embedBuilder = new();
+                        FormatDocumentationList(embedBuilder, foundDocs);
 
-            _logger.LogDebug("Documentation found for: {Query}.", documentation.DisplayName);
-            if (documentation.SourceUri.IsValueCreated)
-            {
-                await context.RespondAsync(documentation.Content);
-                return;
+                        await context.RespondAsync(embedBuilder);
+                    }
+                    break;
             }
-
-            // Defer
-            await context.DeferResponseAsync();
-            Uri? source = await documentation.SourceUri.Value;
-            if (source is not null)
-            {
-                string[] lines = documentation.Content.Split('\n');
-                lines[0] = $"## [{lines[0][3..]}](<{source}>)";
-                documentation.Content = string.Join('\n', lines);
-            }
-
-            await context.EditResponseAsync(documentation.Content);
         }
 
         public ValueTask<IEnumerable<DiscordAutoCompleteChoice>> AutoCompleteAsync(AutoCompleteContext context)
@@ -101,7 +103,7 @@ namespace OoLunar.DocBot.Commands
                 string trimmedDisplayName = member.DisplayName.TrimLength(100);
                 DiscordAutoCompleteChoice choice = new(trimmedDisplayName,
                     member.GetHashCode().ToString(CultureInfo.InvariantCulture));
-                
+
                 if (!choices.TryAdd(trimmedDisplayName, choice))
                 {
                     continue;
@@ -114,6 +116,47 @@ namespace OoLunar.DocBot.Commands
             }
 
             return ValueTask.FromResult<IEnumerable<DiscordAutoCompleteChoice>>(choices.Values);
+        }
+
+        private async Task ReplyWithDocumentationAsync(CommandContext context, DocumentationMember foundDocs)
+        {
+            _logger.LogDebug("Documentation found for: {Query}.", foundDocs.DisplayName);
+            if (foundDocs.SourceUri.IsValueCreated)
+            {
+                await context.RespondAsync(foundDocs.Content);
+                return;
+            }
+
+            // Defer
+            await context.DeferResponseAsync();
+            Uri? source = await foundDocs.SourceUri.Value;
+            if (source is not null)
+            {
+                string[] lines = foundDocs.Content.Split('\n');
+                lines[0] = $"## [{lines[0][3..]}](<{source}>)";
+                foundDocs.Content = string.Join('\n', lines);
+            }
+
+            await context.EditResponseAsync(foundDocs.Content);
+        }
+
+        private static void FormatDocumentationList(DiscordEmbedBuilder embedBuilder, List<DocumentationMember> foundDocs)
+        {
+            embedBuilder.WithTitle($"Your query returned {foundDocs.Count} matching items!")
+                .WithColor(0xEED202);
+
+            foreach (DocumentationMember member in foundDocs)
+            {
+                // Plus one to account for final period
+                int trimLength = member.DisplayName.Length + 1;
+
+                if (member.DisplayName.EndsWith("()"))
+                {
+                    trimLength -= 2;
+                }
+
+                embedBuilder.AddField(member.DisplayName, member.FullName[..^trimLength]);
+            }
         }
     }
 }

--- a/src/DocumentationProvider.cs
+++ b/src/DocumentationProvider.cs
@@ -64,6 +64,36 @@ namespace OoLunar.DocBot
             return;
         }
 
+        public IEnumerable<DocumentationMember> FindMatchingDocs(string query)
+        {
+            List<DocumentationMember> foundDocs = [];
+
+            if (int.TryParse(query, out int id)
+                && Members.TryGetValue(id, out DocumentationMember? foundDockMember))
+            {
+                foundDocs.Add(foundDockMember);
+            }
+            else
+            {
+                foreach (DocumentationMember member in Members.Values)
+                {
+                    if (member.FullName.Equals(query, StringComparison.OrdinalIgnoreCase)
+                        || member.DisplayName.Equals(query, StringComparison.OrdinalIgnoreCase))
+                    {
+                        foundDocs.Clear();
+                        foundDocs.Add(member);
+                        break;
+                    }
+                    else if (member.DisplayName.Contains(query, StringComparison.OrdinalIgnoreCase))
+                    {
+                        foundDocs.Add(member);
+                    }
+                }
+            }
+
+            return foundDocs;
+        }
+
         private async Task<ConcurrentQueue<DocumentationMember>> GetMembersAsync(IEnumerable<Assembly> assemblies)
         {
             ConcurrentQueue<DocumentationMember> members = new();


### PR DESCRIPTION
# Summary
Reworks how documentation is searched, and also how a response is formed based on what documentation is found.

# Details
* The documentation location logic from `DocumentationComand.GetDocumentation` has been moved to `DocumentationProvider.FindMatchingDocs` (which returns an enumeration of document members).
* The response logic has been extracted to respective methods based on the number of found `DocumentationMember`s.
  - No documentation found results in the original message "No documentation found".
  - Only one document results in the original documentation message.
  - More than twenty-five documentation members found results in an embed with the text "More than 25 items matched your query! Please refine your search and try again!".
  - More than one documentation member (while being less than twenty-five) results in an embed with each member found. This method does not check for the 1024-character limit and may lead to an exception.

This is an example usage when looking for the type `CommandNotFoundException`:
![image](https://github.com/user-attachments/assets/52d30e42-cb57-450e-aa47-29ce6b694811)

Before, it would return information on `CommandNotFoundException.ToString()` because the check of `member.DisplayName.Contains` would continuously replace the found document member until the enumeration stopped, ending with the `ToString()` method being selected.

This is an example response when more than one result is found:
![image](https://github.com/user-attachments/assets/f46c5de3-6c22-42fc-acdd-8a7e406599dd)
It doesn't look flashy, but it gets the job done, so long as it doesn't exceed the character limit.