### PR TITLE
Trim autocomplete input

### DIFF
--- a/src/Commands/DocumentationCommand.cs
+++ b/src/Commands/DocumentationCommand.cs
@@ -76,7 +76,7 @@ namespace OoLunar.DocBot.Commands
 
         public ValueTask<IEnumerable<DiscordAutoCompleteChoice>> AutoCompleteAsync(AutoCompleteContext context)
         {
-            string query = context.UserInput ?? string.Empty;
+            string query = context.UserInput?.Trim() ?? string.Empty;
             _logger.LogDebug("Querying documentation for: \"{Query}\"", query);
 
             Dictionary<string, DiscordAutoCompleteChoice> choices = [];


### PR DESCRIPTION
Does what the title implies. The great discord ui makes it a bit tricky to see spaces before the query for example which leads to not finding things when you copy and paste unlucky